### PR TITLE
Add CSS overrides and runtime loader

### DIFF
--- a/assets/overrides-loader.js
+++ b/assets/overrides-loader.js
@@ -1,0 +1,1 @@
+document.addEventListener('DOMContentLoaded', function(){var l=document.createElement('link');l.rel='stylesheet';l.href='/assets/overrides.css';document.head.appendChild(l);});

--- a/assets/overrides.css
+++ b/assets/overrides.css
@@ -1,0 +1,1 @@
+.site-footer .footer-col p {\n  text-align: left;\n}\n\n@media screen and (max-width: 600px) {\n  .site-footer .footer-col p {\n    text-align: center;\n  }\n}\n


### PR DESCRIPTION
Add a small overrides.css and a JS loader that injects it after the theme CSS to safely tweak footer alignment without overriding theme includes.