### PR TITLE
Inject overrides loader via local head include

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -1,0 +1,7 @@
+<meta charset="utf-8">
+<meta http-equiv="X-UA-Compatible" content="IE=edge">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+{% seo %}
+<link rel="stylesheet" href="{{ '/assets/main.css' | relative_url }}">
+<link type="application/atom+xml" rel="alternate" href="{{ '/feed.xml' | absolute_url }}" title="{{ site.title }}" />
+<script src="{{ '/assets/overrides-loader.js' | relative_url }}" defer></script>


### PR DESCRIPTION
Provide a local _includes/head.html that preserves essential head tags and injects the overrides loader script so overrides apply sitewide.